### PR TITLE
Make it so I have to type less

### DIFF
--- a/commandpermissions.json
+++ b/commandpermissions.json
@@ -26,7 +26,7 @@
         {
             "tour":
             {
-                "legavgc": ["vgc13"],
+                "legavgc": ["13"],
                 "bennbuild": ["18"]
             },
             "blog":

--- a/commandpermissions.json
+++ b/commandpermissions.json
@@ -27,7 +27,7 @@
             "tour":
             {
                 "legavgc": ["vgc13"],
-                "bennbuild": ["vgc18"]
+                "bennbuild": ["18"]
             },
             "blog":
             {


### PR DESCRIPTION
Current implementation makes it so I can only do ".tour vgc18" specifically, as it checks for perms before checking aliases. Therefore, to make it so I have to type less, I have changed my perm from vgc18 to 18